### PR TITLE
Source switch for gzipped index pages

### DIFF
--- a/GzipSimpleHTTPServer.py
+++ b/GzipSimpleHTTPServer.py
@@ -36,15 +36,15 @@ def parse_options():
     global encoding_type
     parser.add_option("-e", "--encoding", dest="encoding_type",
                       help="Encoding type for server to utilize",
-                      metavar="ENCODING", default=encoding_type)
+                      metavar=encoding_type, default=encoding_type)
     global SERVER_PORT
     parser.add_option("-p", "--port", dest="port", default=SERVER_PORT,
                       help="The port to serve the files on",
-                      metavar="ENCODING")
+                      metavar=SERVER_PORT)
     global source
     parser.add_option("-s", "--source", dest="source",
                       help="Pick what file to serve ['index.html', 'index.htm', 'index.html.gz', 'index.htm.gz', 'index.gz'], default will serve in this order",
-                      metavar="ENCODING", default='')
+                      metavar="index.htm.gz", default='')
     (options, args) = parser.parse_args()
     encoding_type = options.encoding_type
     SERVER_PORT = int(options.port)

--- a/GzipSimpleHTTPServer.py
+++ b/GzipSimpleHTTPServer.py
@@ -132,7 +132,6 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                     if os.path.exists(index):
                         path = index
                     else:
-                        print("Couldn't load: " % path)
                         return self.list_directory(path).read()
             else:
                 for index in source_files:
@@ -146,7 +145,11 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                         break
                 else:
                     return self.list_directory(path).read()
-        ctype = self.guess_type(path)
+
+        if not source_type == 'normal':
+            type = source_type
+
+        ctype = self.guess_type(path, type)
         print("Serving path '%s'" % path)
         try:
             # Always read in binary mode. Opening files in text mode may cause
@@ -162,9 +165,6 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         fs = os.fstat(f.fileno())
         raw_content_length = fs[6]
         content = f.read()
-
-        if not source_type == 'normal':
-            type = source_type
 
         if type == 'normal':
             # Encode content based on runtime arg
@@ -246,7 +246,7 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             path = os.path.join(path, word)
         return path
 
-    def guess_type(self, path):
+    def guess_type(self, path, type):
         """Guess the type of a file.
 
         Argument is a PATH (a filename).
@@ -262,11 +262,11 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         """
 
         base, ext = posixpath.splitext(path)
+        if type == 'gzipped':
+            return self.extensions_map['.gzipped']
         if ext in self.extensions_map:
             return self.extensions_map[ext]
         ext = ext.lower()
-        if source_type == 'gzipped':
-            return self.extensions_map['.gzipped']
         if ext in self.extensions_map:
             return self.extensions_map[ext]
         else:

--- a/GzipSimpleHTTPServer.py
+++ b/GzipSimpleHTTPServer.py
@@ -27,36 +27,22 @@ except ImportError:
 
 SERVER_PORT = 8000
 encoding_type = 'gzip'
-source = ''
-source_files = ['index.html', 'index.htm', 'index.html.gz', 'index.htm.gz', 'index.gz']
 
 def parse_options():
     # Option parsing logic.
     parser = OptionParser()
-    global encoding_type
     parser.add_option("-e", "--encoding", dest="encoding_type",
                       help="Encoding type for server to utilize",
-                      metavar="ENCODING", default=encoding_type)
+                      metavar="ENCODING", default='gzip')
     global SERVER_PORT
     parser.add_option("-p", "--port", dest="port", default=SERVER_PORT,
                       help="The port to serve the files on",
                       metavar="ENCODING")
-    global source
-    parser.add_option("-s", "--source", dest="source",
-                      help="Pick what file to serve ['index.html', 'index.htm', 'index.html.gz', 'index.htm.gz', 'index.gz'], default will serve in this order",
-                      metavar="ENCODING", default='')
     (options, args) = parser.parse_args()
+    global encoding_type
     encoding_type = options.encoding_type
     SERVER_PORT = int(options.port)
-    source = options.source
-    global source_type
-    base, ext = posixpath.splitext(source)
-    ext = ext.lower()
-    if ext == '.gz':
-        source_type = 'gzipped'
-    else:
-        source_type = 'normal'
-    global source_files
+
     if encoding_type not in ['zlib', 'deflate', 'gzip']:
         sys.stderr.write("Please provide a valid encoding_type for the server to utilize.\n")
         sys.stderr.write("Possible values are 'zlib', 'gzip', and 'deflate'\n")
@@ -118,8 +104,8 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
         """
         path = self.translate_path(self.path)
+        print("Serving path '%s'" % path)
         f = None
-        type = 'normal'
         if os.path.isdir(path):
             if not self.path.endswith('/'):
                 # redirect browser - doing basically what apache does
@@ -127,26 +113,14 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 self.send_header("Location", self.path + "/")
                 self.end_headers()
                 return None
-            if not source == '':
-                    index = os.path.join(path, source)
-                    if os.path.exists(index):
-                        path = index
-                    else:
-                        return self.list_directory(path).read()
+            for index in "index.html", "index.htm":
+                index = os.path.join(path, index)
+                if os.path.exists(index):
+                    path = index
+                    break
             else:
-                for index in source_files:
-                    index = os.path.join(path, index)
-                    if os.path.exists(index):
-                        base, ext = posixpath.splitext(index)
-                        ext = ext.lower()
-                        if ext == '.gz':
-                            type = 'gzipped'
-                        path = index
-                        break
-                else:
-                    return self.list_directory(path).read()
+                return self.list_directory(path).read()
         ctype = self.guess_type(path)
-        print("Serving path '%s'" % path)
         try:
             # Always read in binary mode. Opening files in text mode may cause
             # newline translations, making the actual size of the content
@@ -162,17 +136,13 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         raw_content_length = fs[6]
         content = f.read()
 
-        if not source_type == 'normal':
-            type = source_type
-
-        if type == 'normal':
-            # Encode content based on runtime arg
-            if encoding_type == "gzip":
-                content = gzip_encode(content)
-            elif encoding_type == "deflate":
-                content = deflate_encode(content)
-            elif encoding_type == "zlib":
-                content = zlib_encode(content)
+        # Encode content based on runtime arg
+        if encoding_type == "gzip":
+            content = gzip_encode(content)
+        elif encoding_type == "deflate":
+            content = deflate_encode(content)
+        elif encoding_type == "zlib":
+            content = zlib_encode(content)
 
         compressed_content_length = len(content)
         f.close()
@@ -264,8 +234,6 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         if ext in self.extensions_map:
             return self.extensions_map[ext]
         ext = ext.lower()
-        if source_type == 'gzipped':
-            return self.extensions_map['.gz']
         if ext in self.extensions_map:
             return self.extensions_map[ext]
         else:
@@ -276,10 +244,9 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     extensions_map = mimetypes.types_map.copy()
     extensions_map.update({
         '': 'application/octet-stream', # Default
-        '.gz': 'text/html',
         '.py': 'text/plain',
         '.c': 'text/plain',
-        '.h': 'text/plain'
+        '.h': 'text/plain',
         })
 
 
@@ -294,7 +261,7 @@ def test(HandlerClass = SimpleHTTPRequestHandler,
 
     parse_options()
 
-    server_address = ('localhost', SERVER_PORT)
+    server_address = ('0.0.0.0', SERVER_PORT)
 
     SimpleHTTPRequestHandler.protocol_version = "HTTP/1.0"
     httpd = BaseHTTPServer.HTTPServer(server_address, SimpleHTTPRequestHandler)

--- a/GzipSimpleHTTPServer.py
+++ b/GzipSimpleHTTPServer.py
@@ -132,6 +132,7 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                     if os.path.exists(index):
                         path = index
                     else:
+                        print("Couldn't load: " % path)
                         return self.list_directory(path).read()
             else:
                 for index in source_files:
@@ -265,7 +266,7 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             return self.extensions_map[ext]
         ext = ext.lower()
         if source_type == 'gzipped':
-            return self.extensions_map['.gz']
+            return self.extensions_map['.gzipped']
         if ext in self.extensions_map:
             return self.extensions_map[ext]
         else:
@@ -276,7 +277,7 @@ class SimpleHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     extensions_map = mimetypes.types_map.copy()
     extensions_map.update({
         '': 'application/octet-stream', # Default
-        '.gz': 'text/html',
+        '.gzipped': 'text/html',
         '.py': 'text/plain',
         '.c': 'text/plain',
         '.h': 'text/plain'


### PR DESCRIPTION
I wanted to allow for ['index.html', 'index.htm', 'index.html.gz', 'index.htm.gz', 'index.gz'] to be used as root source. If no --source option is made it will pick from this list (the first to be found). If you want to specify what root source to use just give the file name (must be in the list of possible sources).